### PR TITLE
chore: bump requests to 2.32.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.31.0
+requests==2.32.5
 sanction==0.4.1


### PR DESCRIPTION
update the requests dependency to the latest patch release to address compatibility and security fixes.